### PR TITLE
feat: add the lambda to start the run by writing to s3

### DIFF
--- a/src/node/lib/start-test-plan.js
+++ b/src/node/lib/start-test-plan.js
@@ -1,0 +1,25 @@
+"use strict"
+const AWS = require('aws-sdk');
+const path = require('path');
+const util = require('util');
+
+const START_FN = 'RUN.TXT'
+
+exports.handler = (event, context, callback) => {
+    let s3 = new AWS.S3({apiVersion: '2006-03-01'});
+    let key = path.posix.join(event.plan_uuid, event.run_uuid, START_FN);
+    let now = Math.round(new Date().getTime() / 1000);
+    let s3_url = util.format("s3://%s/%s", event.bucket, key);
+
+    s3.upload({
+        Bucket: event.bucket,
+        Key: key,
+        Body: new Buffer(now.toString(), 'binary'),
+        ACL: 'public-read'
+    }).promise().then((data) => {
+        console.log("Uploaded: ", s3_url);
+        callback();
+    }).catch((err) => {
+        callback(err, "Error while uploading to: ", s3_url);
+    });
+}

--- a/src/node/package.json
+++ b/src/node/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ardere-lambda-functions",
+  "version": "0.0.1",
+  "description": "Ardere AWS Lambda functions",
+  "engines": {
+    "node": "^4.3.x",
+    "npm": "^3.5.x"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "author": "Mozilla Loads Project",
+  "license": "MPL",
+  "devDependencies": {
+    "aws-sdk-mock": "^1.6.1",
+    "chai": "^3.5.0",
+    "lambda-tester": "^2.7.0",
+    "mocha": "^3.2.0"
+  }
+}

--- a/src/node/test/test-start-test-plan.js
+++ b/src/node/test/test-start-test-plan.js
@@ -1,0 +1,34 @@
+"use strict"
+const AWS = require('aws-sdk-mock');
+const LambdaTester = require('lambda-tester');
+
+const assert = require('chai').assert;
+const handler = require('../lib/start-test-plan.js').handler;
+
+describe('start test plan', () => {
+    let upload;
+
+    before(() => {
+        upload = AWS.mock('S3', 'upload', (params, callback) => {
+            callback(null, "Uploaded");
+        });
+    });
+
+    after(() => {
+        AWS.restore('S3');
+    });
+
+    it('uploaded start file to s3', () => {
+        return LambdaTester(handler)
+            .event({bucket: 'foo', plan_uuid: 'abcd', run_uuid: 'efgh'})
+            .expectResult((result) => {
+                assert(upload.stub.calledOnce);
+                let params = upload.stub.args[0][0];
+                assert(params.Bucket == 'foo');
+                assert(params.Key == 'abcd/efgh/RUN.TXT');
+                assert(params.ACL.includes('public'));
+                let start_time = parseInt(params.Body.toString());
+                assert(start_time <= Math.ceil(new Date().getTime() / 1000));
+            });
+    });
+});


### PR DESCRIPTION
and mocha/chai testing w/ lambda-tester & aws-sdk-mock

closes #4