### PR TITLE
feat: add toml loading as a test plan

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 futures==3.0.5
 typing==3.5.3.0
+toml==0.9.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
-futures==3.0.5
-typing==3.5.3.0
+-r requirements.txt
 nose==1.3.7
 mock==2.0.0
 coverage==4.3.4

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -20,6 +20,35 @@ sample_basic_test_plan = """
 }
 """
 
+sample_toml = """
+ecs_name = "ardere-test"
+name = "connection loadtest"
+description = "autopush: connect and idle forever"
+
+
+[[steps]]
+    name = "***************** RUN #01 ***********************"
+    instance_count = 8
+    instance_type = "m3.medium"
+    container_name = "bbangert/ap-loadtester:latest"
+    additional_command_args = "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:connect_and_idle_forever,10000,5,0'"
+    run_max_time = 300
+    volume_mapping = "/var/log:/var/log/$RUN_ID:rw"
+    docker_series = "push_tests"
+
+[[steps]]
+    name = "***************** RUN #02 ***********************"
+    instance_count = 8
+    run_delay = 330
+    instance_type = "m3.medium"
+    container_name = "bbangert/ap-loadtester:latest"
+    additional_command_args = "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:connect_and_idle_forever,10000,5,0'"
+    run_max_time = 300
+    volume_mapping = "/var/log:/var/log/$RUN_ID:rw"
+    docker_series = "push_tests"
+
+"""
+
 future_hypothetical_test="""
 {
     "name": "TestCluster",

--- a/tests/test_step_functions.py
+++ b/tests/test_step_functions.py
@@ -36,6 +36,15 @@ class TestAsyncPlanRunner(unittest.TestCase):
         result = self.runner._find_test_plan_duration()
         eq_(result, 140)
 
+    def test_load_toml(self):
+        from ardere.step_functions import AsynchronousPlanRunner
+
+        self.runner = AsynchronousPlanRunner({"toml": fixtures.sample_toml},
+                                             None)
+        eq_(len(self.runner.event["steps"]), 2)
+        eq_(self.runner.event["steps"][0]["instance_count"], 8)
+        eq_(self.runner.event["ecs_name"], "ardere-test")
+
     def test_populate_missing_instances(self):
         self.runner.populate_missing_instances()
         self.mock_ecs.query_active_instances.assert_called()


### PR DESCRIPTION
Allows TOML to be loaded if specified as the 'toml' key in the event
dict passed into the step function.

Closes #32