### PR TITLE
feat: add port mapping for containers

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -13,6 +13,7 @@ sample_basic_test_plan = """
       "environment_data": [
           "SOME_VAR=great-value"
       ],
+      "port_mapping": "8000,4000",
       "container_name": "bbangert/ap-loadtester:latest",
       "additional_command_args": "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:notification_forever,1000,1,0'"
     }
@@ -28,7 +29,7 @@ future_hypothetical_test="""
     "run_max_time": 140,
     "cpu_units": 2048,
     "container_name": "bbangert/pushgo:1.5rc4",
-    "port_mapping": "8080:8090,8081:8081,3000:3000,8082:8082",
+    "port_mapping": "8080,8081,3000,8082",
     "load_balancer": {
         "env_var": "TEST_CLUSTER",
         "ping_path": "/status/health",

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -97,6 +97,11 @@ class TestECSManager(unittest.TestCase):
         eq_(step["serviceArn"], "arn:of:some:service::")
         ecs._ecs_client.register_task_definition.assert_called()
 
+        _, kwargs = ecs._ecs_client.register_task_definition.call_args
+        container_def = kwargs["containerDefinitions"][0]
+        ok_("portMappings" in container_def)
+        eq_(container_def["networkMode"], "host")
+
     def test_create_services(self):
         ecs = self._make_FUT()
         ecs.create_service = mock.Mock()


### PR DESCRIPTION
Allows the ports specified to be mapped directly into the container.

Closes #24