### PR TITLE
feat: remove need to specify cpu_units

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -9,7 +9,6 @@ sample_basic_test_plan = """
       "instance_count": 1,
       "instance_type": "t2.medium",
       "run_max_time": 140,
-      "cpu_units": 2048,
       "environment_data": [
           "SOME_VAR=great-value"
       ],
@@ -56,7 +55,6 @@ future_hypothetical_test="""
     "instance_count": 1,
     "instance_type": "t2.medium",
     "run_max_time": 140,
-    "cpu_units": 2048,
     "container_name": "bbangert/pushgo:1.5rc4",
     "port_mapping": "8080,8081,3000,8082",
     "load_balancer": {

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -96,6 +96,10 @@ class TestECSManager(unittest.TestCase):
 
         eq_(step["serviceArn"], "arn:of:some:service::")
         ecs._ecs_client.register_task_definition.assert_called()
+        _, kwargs = ecs._ecs_client.register_task_definition.call_args
+        container_def = kwargs["containerDefinitions"][0]
+
+        eq_(container_def["cpu"], 1536)
 
         _, kwargs = ecs._ecs_client.register_task_definition.call_args
         container_def = kwargs["containerDefinitions"][0]


### PR DESCRIPTION
We not allocate sufficient cpu units to ensure distinct task
placement across the cluster without forcing the test plan to
take it into account.

Closes #20