### PR TITLE
feat: start influxdb with test runs

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -12,6 +12,9 @@ def populate_missing_instances(event, context):
     runner = AsynchronousPlanRunner(event, context)
     return runner.populate_missing_instances()
 
+def ensure_metrics_available(event, context):
+    runner = AsynchronousPlanRunner(event, context)
+    return runner.ensure_metrics_available()
 
 def create_ecs_services(event, context):
     runner = AsynchronousPlanRunner(event, context)

--- a/serverless.yml
+++ b/serverless.yml
@@ -23,6 +23,8 @@ provider:
         - Arn
     s3_ready_bucket:
       Ref: "S3ReadyBucket"
+    metrics_bucket:
+      Ref: "MetricsBucket"
     container_log_group:
       Ref: "ContainerLogs"
 
@@ -77,6 +79,8 @@ provider:
 functions:
   populate_missing_instances:
     handler: handler.populate_missing_instances
+  ensure_metrics_available:
+    handler: handler.ensure_metrics_available
   create_ecs_services:
     handler: handler.create_ecs_services
   wait_for_cluster_ready:
@@ -98,6 +102,17 @@ stepFunctions:
         "Populate Missing Instances":
           Type: Task
           Resource: populate_missing_instances
+          Next: "Ensure Metrics Available"
+        "Ensure Metrics Available":
+          Type: Task
+          Resource: ensure_metrics_available
+          Retry:
+            -
+              ErrorEquals:
+                - ServicesStartingException
+              IntervalSeconds: 10
+              MaxAttempts: 60
+              BackoffRate: 1
           Next: "Create ECS Services"
         "Create ECS Services":
           Type: Task
@@ -167,7 +182,11 @@ resources:
     S3ReadyBucket:
       Type: "AWS::S3::Bucket"
       Properties:
-        AccessControl: "PublicRead"
+        AccessControl: "AuthenticatedRead"
+    MetricsBucket:
+      Type: "AWS::S3::Bucket"
+      Properties:
+        AccessControl: "AuthenticatedRead"
     EC2ContainerRole:
       Type: "AWS::IAM::Role"
       Properties:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -14,7 +14,7 @@ sample_basic_test_plan = """
       },
       "port_mapping": [8000, 4000],
       "container_name": "bbangert/ap-loadtester:latest",
-      "command": "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:notification_forever,1000,1,0'"
+      "cmd": "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:notification_forever,1000,1,0'"
     }
   ]
 }
@@ -31,7 +31,7 @@ description = "autopush: connect and idle forever"
     instance_count = 8
     instance_type = "m3.medium"
     container_name = "bbangert/ap-loadtester:latest"
-    command = "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:connect_and_idle_forever,10000,5,0'"
+    cmd = "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:connect_and_idle_forever,10000,5,0'"
     run_max_time = 300
     volume_mapping = "/var/log:/var/log/$RUN_ID:rw"
     docker_series = "push_tests"
@@ -42,7 +42,7 @@ description = "autopush: connect and idle forever"
     run_delay = 330
     instance_type = "m3.medium"
     container_name = "bbangert/ap-loadtester:latest"
-    command = "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:connect_and_idle_forever,10000,5,0'"
+    cmd = "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:connect_and_idle_forever,10000,5,0'"
     run_max_time = 300
     volume_mapping = "/var/log:/var/log/$RUN_ID:rw"
     docker_series = "push_tests"


### PR DESCRIPTION
Add's an influx_options to the plan to choose whether to create an
InfluxDB container instance and populate its IP to the plan for later
setup of telegraf. Can also be optionally torn down at the end of the
test run.

Closes #19