### PR TITLE
feat: add telegraf setup for per-container stat reporting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ futures==3.0.5
 typing==3.5.3.0
 toml==0.9.2
 marshmallow==2.13.4
+influxdb==4.0.0

--- a/serverless.yml
+++ b/serverless.yml
@@ -182,7 +182,7 @@ resources:
     S3ReadyBucket:
       Type: "AWS::S3::Bucket"
       Properties:
-        AccessControl: "AuthenticatedRead"
+        AccessControl: "PublicRead"
     MetricsBucket:
       Type: "AWS::S3::Bucket"
       Properties:

--- a/src/shell/telegraf.toml
+++ b/src/shell/telegraf.toml
@@ -1,0 +1,177 @@
+# Telegraf Configuration
+#
+# Telegraf is entirely plugin driven. All metrics are gathered from the
+# declared inputs, and sent to the declared outputs.
+#
+# Plugins must be declared in here to be active.
+# To deactivate a plugin, comment out the name and any variables.
+#
+# Use 'telegraf -config telegraf.conf -test' to see what metrics a config
+# file would generate.
+#
+# Environment variables can be used anywhere in this config file, simply prepend
+# them with $. For strings the variable must be within quotes (ie, "$STR_VAR"),
+# for numbers and booleans they should be plain (ie, $INT_VAR, $BOOL_VAR)
+
+
+# Global tags can be specified here in key="value" format.
+[global_tags]
+# dc = "us-east-1" # will tag all metrics with dc=us-east-1
+# rack = "1a"
+## Environment variables can be used as tags, and throughout the config file
+# user = "$USER"
+step = "$__ARDERE_TELEGRAF_STEP__"
+## type is the old "docker_series"
+type = "$__ARDERE_TELEGRAF_TYPE__"
+
+
+# Configuration for telegraf agent
+[agent]
+## Default data collection interval for all inputs
+interval = "10s"
+## Rounds collection interval to 'interval'
+## ie, if interval="10s" then always collect on :00, :10, :20, etc.
+round_interval = true
+
+## Telegraf will send metrics to outputs in batches of at most
+## metric_batch_size metrics.
+## This controls the size of writes that Telegraf sends to output plugins.
+metric_batch_size = 1000
+
+## For failed writes, telegraf will cache metric_buffer_limit metrics for each
+## output, and will flush this buffer on a successful write. Oldest metrics
+## are dropped first when this buffer fills.
+## This buffer only fills when writes fail to output plugin(s).
+metric_buffer_limit = 10000
+
+## Collection jitter is used to jitter the collection by a random amount.
+## Each plugin will sleep for a random time within jitter before collecting.
+## This can be used to avoid many plugins querying things like sysfs at the
+## same time, which can have a measurable effect on the system.
+collection_jitter = "0s"
+
+## Default flushing interval for all outputs. You shouldn't set this below
+## interval. Maximum flush_interval will be flush_interval + flush_jitter
+flush_interval = "10s"
+## Jitter the flush interval by a random amount. This is primarily to avoid
+## large write spikes for users running a large number of telegraf instances.
+## ie, a jitter of 5s and interval 10s means flushes will happen every 10-15s
+flush_jitter = "0s"
+## By default, precision will be set to the same timestamp order as the
+## collection interval, with the maximum being 1s.
+## Precision will NOT be used for service inputs, such as logparser and statsd.
+## Valid values are "ns", "us" (or "µs"), "ms", "s".
+precision = ""
+## Logging configuration:
+## Run telegraf with debug log messages.
+debug = false
+## Run telegraf in quiet mode (error log messages only).
+quiet = false
+## Specify the log file name. The empty string means to log to stderr.
+logfile = ""
+## Override default hostname, if empty use os.Hostname()
+hostname = "$__ARDERE_TELEGRAF_HOST__"
+## If set to true, do no set the "host" tag in the telegraf agent.
+omit_hostname = false
+###############################################################################
+#                            OUTPUT PLUGINS                                   #
+###############################################################################
+# Configuration for influxdb server to send metrics to
+[[outputs.influxdb]]
+## The full HTTP or UDP endpoint URL for your InfluxDB instance.
+## Multiple urls can be specified as part of the same cluster,
+## this means that only ONE of the urls will be written to each interval.
+# urls = ["udp://localhost:8089"] # UDP endpoint example
+urls = ["http://$__ARDERE_INFLUX_ADDR__"] # required
+## The target database for metrics (telegraf will create it if not exists).
+database = "$__ARDERE_INFLUX_DB__" # required
+## Retention policy to write to. Empty string writes to the default rp.
+retention_policy = ""
+## Write consistency (clusters only), can be: "any", "one", "quorum", "all"
+write_consistency = "any"
+## Write timeout (for the InfluxDB client), formatted as a string.
+## If not provided, will default to 5s. 0s means no timeout (not recommended).
+timeout = "5s"
+# username = "telegraf"
+# password = "metricsmetricsmetricsmetrics"
+## Set the user agent for HTTP POSTs (can be useful for log differentiation)
+# user_agent = "telegraf"
+## Set UDP payload size, defaults to InfluxDB UDP Client default (512 bytes)
+# udp_payload = 512
+## Optional SSL Config
+# ssl_ca = "/etc/telegraf/ca.pem"
+# ssl_cert = "/etc/telegraf/cert.pem"
+# ssl_key = "/etc/telegraf/key.pem"
+## Use SSL but skip chain & host verification
+# insecure_skip_verify = false
+###############################################################################
+#                            PROCESSOR PLUGINS                                #
+###############################################################################
+# # Print all metrics that pass through this filter.
+# [[processors.printer]]
+###############################################################################
+#                            AGGREGATOR PLUGINS                               #
+###############################################################################
+# # Keep the aggregate min/max of each metric passing through.
+# [[aggregators.minmax]]
+#   ## General Aggregator Arguments:
+#   ## The period on which to flush & clear the aggregator.
+#   period = "30s"
+#   ## If true, the original metric will be dropped by the
+#   ## aggregator and will not get sent to the output plugins.
+#   drop_original = false
+###############################################################################
+#                            INPUT PLUGINS                                    #
+###############################################################################
+# Read metrics about cpu usage
+[[inputs.cpu]]
+## Whether to report per-cpu stats or not
+percpu = true
+## Whether to report total system cpu stats or not
+totalcpu = true
+## If true, collect raw CPU time metrics.
+collect_cpu_time = false
+# Read metrics about memory usage
+[[inputs.mem]]
+# no configuration
+# Read TCP metrics such as established, time wait and sockets counts.
+[[inputs.netstat]]
+# no configuration
+###############################################################################
+#                            SERVICE INPUT PLUGINS                            #
+###############################################################################
+# Statsd Server
+[[inputs.statsd]]
+## Address and port to host UDP listener on
+service_address = ":8125"
+## The following configuration options control when telegraf clears it's cache
+## of previous values. If set to false, then telegraf will only clear it's
+## cache when the daemon is restarted.
+## Reset gauges every interval (default=true)
+delete_gauges = true
+## Reset counters every interval (default=true)
+delete_counters = true
+## Reset sets every interval (default=true)
+delete_sets = true
+## Reset timings & histograms every interval (default=true)
+delete_timings = true
+## Percentiles to calculate for timing & histogram stats
+percentiles = [90]
+## separator to use between elements of a statsd metric
+metric_separator = "_"
+## Parses tags in the datadog statsd format
+## http://docs.datadoghq.com/guides/dogstatsd/
+parse_data_dog_tags = false
+## Statsd data translation templates, more info can be read here:
+## https://github.com/influxdata/telegraf/blob/master/docs/DATA_FORMATS_INPUT.md#graphite
+# templates = [
+#     "cpu.* measurement*"
+# ]
+## Number of UDP messages allowed to queue up, once filled,
+## the statsd server will start dropping packets
+allowed_pending_messages = 10000
+## Number of timing/histogram values to track per-measurement in the
+## calculation of percentiles. Raising this limit increases the accuracy
+## of percentiles but also increases the memory usage and cpu time.
+#percentile_limit = 1000
+percentile_limit = 10

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -14,7 +14,7 @@ sample_basic_test_plan = """
       },
       "port_mapping": [8000, 4000],
       "container_name": "bbangert/ap-loadtester:latest",
-      "cmd": "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:notification_forever,1000,1,0'"
+      "cmd": "./apenv/bin/aplt_testplan wss://autopush.stage.mozaws.net 'aplt.scenarios:notification_forever,1000,1,0' --statsd_host=localhost --statsd_port=8125"
     }
   ]
 }

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -107,11 +107,11 @@ class TestECSManager(unittest.TestCase):
         ecs = self._make_FUT()
         ecs._ecs_client.describe_services.return_value = {
             "services": [
-                {"stuff": 1}
+                {"stuff": 1, "status": "ACTIVE"}
             ]
         }
         result = ecs.locate_metrics_service()
-        eq_(result, {"stuff": 1})
+        eq_(result, {"stuff": 1, "status": "ACTIVE"})
 
     def test_locate_metrics_service_not_found(self):
         ecs = self._make_FUT()
@@ -141,6 +141,8 @@ class TestECSManager(unittest.TestCase):
         ecs = self._make_FUT()
 
         step = ecs._plan["steps"][0]
+        ecs._plan["influxdb_public_ip"] = "1.1.1.1"
+        step["docker_series"] = "default"
 
         # Setup mocks
         ecs._ecs_client.register_task_definition.return_value = {

--- a/tests/test_step_functions.py
+++ b/tests/test_step_functions.py
@@ -15,6 +15,9 @@ class TestAsyncPlanRunner(unittest.TestCase):
     def setUp(self):
         self.mock_ecs = mock.Mock()
         self._patcher = mock.patch("ardere.step_functions.ECSManager")
+        self._influx_patcher = mock.patch(
+            "ardere.step_functions.InfluxDBClient")
+        self.mock_influx = self._influx_patcher.start()
         mock_manager = self._patcher.start()
         mock_manager.return_value = self.mock_ecs
 
@@ -25,6 +28,7 @@ class TestAsyncPlanRunner(unittest.TestCase):
         self.runner.boto = self.mock_boto = mock.Mock()
 
     def tearDown(self):
+        self._influx_patcher.stop()
         self._patcher.stop()
 
     def test_build_instance_map(self):
@@ -105,6 +109,7 @@ class TestAsyncPlanRunner(unittest.TestCase):
         self.mock_ecs.locate_metrics_container_ip.return_value = "1.1.1.1"
         self.runner.ensure_metrics_available()
         self.mock_ecs.locate_metrics_container_ip.assert_called()
+        self.mock_influx.assert_called()
 
     def test_ensure_metrics_available_disabled(self):
         self.plan["influx_options"] = dict(enabled=False)


### PR DESCRIPTION
Creates InfluxDB database and sets up all the steps to have
telegraf running when influxdb is enabled.

Closes #33