### PR TITLE
fix: add proper tagging and socket limits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ typing==3.5.3.0
 toml==0.9.2
 marshmallow==2.13.4
 influxdb==4.0.0
+boto3==1.4.4

--- a/serverless.yml
+++ b/serverless.yml
@@ -160,7 +160,7 @@ stepFunctions:
               ErrorEquals:
                 - NoSuchKey
               IntervalSeconds: 10
-              MaxAttempts: 4
+              MaxAttempts: 2
               BackoffRate: 1
           Catch:
             -

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -73,12 +73,7 @@ class TestECSManager(unittest.TestCase):
             "Instances": [{"InstanceId": 12345}]
         }
         ecs.request_instances(instances)
-        ecs._ec2_client.create_tags.assert_called_with(
-            Resources=[12345], Tags=[
-                {'Value': 'ardere', 'Key': 'Owner'},
-                {'Value': u'ardere-test', 'Key': 'ECSCluster'}
-            ]
-        )
+        ecs._ec2_client.run_instances.assert_called()
 
     def test_locate_metrics_container_ip(self):
         ecs = self._make_FUT()


### PR DESCRIPTION
Up the socket limits to allow proper outbound connections. Change
tagging call so it's made when running the instances and include
the Name key set to the cluster name for better filtering.

Closes #43, #44