### PR TITLE
fix: check service drained vs container draining

### DIFF
--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -244,6 +244,38 @@ class TestECSManager(unittest.TestCase):
         ecs.all_services_ready(ecs._plan["steps"])
         ecs.service_ready.assert_called()
 
+    def test_service_done_true(self):
+        ecs = self._make_FUT()
+        step = ecs._plan["steps"][0]
+
+        ecs._ecs_client.describe_services.return_value = {
+            "services": [{
+                "status": "INACTIVE"
+            }]
+        }
+
+        result = ecs.service_done(step)
+        eq_(result, True)
+
+    def test_service_not_known(self):
+        ecs = self._make_FUT()
+        step = ecs._plan["steps"][0]
+
+        ecs._ecs_client.describe_services.return_value = {
+            "services": [{
+                "status": "DRAINING"
+            }]
+        }
+
+        result = ecs.service_done(step)
+        eq_(result, False)
+
+    def test_all_services_done(self):
+        ecs = self._make_FUT()
+        ecs.service_done = mock.Mock()
+        ecs.all_services_done(ecs._plan["steps"])
+        ecs.service_done.assert_called()
+
     def test_stop_finished_service_stopped(self):
         ecs = self._make_FUT()
         ecs._ecs_client.update_service = mock.Mock()

--- a/tests/test_step_functions.py
+++ b/tests/test_step_functions.py
@@ -293,61 +293,13 @@ class TestAsyncPlanRunner(unittest.TestCase):
         self.runner.cleanup_cluster()
         mock_s3.Object.assert_called()
 
-    def test_drain_check_active(self):
-        from ardere.exceptions import UndrainedInstancesException
-
-        mock_client = mock.Mock()
-        mock_client.list_container_instances.return_value = {
-            'containerInstanceArns': [
-                'Some-Arn-01234567890',
-                'Metric-Arn-01234567890',
-            ],
-            "nextToken": "token-8675309"
-        }
-        self.mock_boto.client.return_value = mock_client
-        assert_raises(UndrainedInstancesException,
-                      self.runner.check_drained)
-
     def test_drain_check_draining(self):
         from ardere.exceptions import UndrainedInstancesException
-
-        mock_client = mock.Mock()
-        mock_client.list_container_instances.side_effect = [
-            {},
-            {
-                'containerInstanceArns': [
-                    'Some-Arn-01234567890',
-                ],
-                "nextToken": "token-8675309"
-            }
-        ]
-        self.mock_boto.client.return_value = mock_client
+        self.mock_ecs.all_services_done.return_value = True
+        self.runner.check_drained()
+        self.mock_ecs.all_services_done.return_value = False
         assert_raises(UndrainedInstancesException,
                       self.runner.check_drained)
-
-    def test_drain_check(self):
-        # Include a "metrics" instance to show that we ignore it.
-        self.plan["metrics_options"] = dict(enabled=True)
-        self.mock_ecs.locate_metrics_service.return_value = {
-            "deployments": [{
-                "desiredCount": 1,
-                "runningCount": 1
-            }],
-            "serviceArn": "Metric-Arn-01234567890"
-        }
-
-        mock_client = mock.Mock()
-        mock_client.list_container_instances.side_effect = [
-            {  # Actives
-                'containerInstanceArns': [
-                    'Metric-Arn-01234567890',
-                ],
-                "nextToken": "token-8675309"
-            },
-            {}  # Draining
-        ]
-        self.mock_boto.client.return_value = mock_client
-        self.runner.check_drained()
 
 
 class TestValidation(unittest.TestCase):


### PR DESCRIPTION
Check drained was checking for container instance draining which is
different from ensuring all services were fully drained. This changes
the check to verify the services have drained completely and are
inactive.

Closes #62