### PR TITLE
fix: give create_ecs_services more time to complete

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -110,6 +110,7 @@ functions:
     timeout: 300
   create_ecs_services:
     handler: handler.create_ecs_services
+    timeout: 300
   wait_for_cluster_ready:
     handler: handler.wait_for_cluster_ready
   signal_cluster_start:


### PR DESCRIPTION
the 6 second default isn't enough for a 5 step 30 node test plan

fixes #78 

I just gave it 300 seconds to match the other initialization functions, feel free to suggest something different